### PR TITLE
Add AuthorizationServerId to Startup.cs

### DIFF
--- a/self-hosted-login/okta-aspnet-webforms-example/Startup.cs
+++ b/self-hosted-login/okta-aspnet-webforms-example/Startup.cs
@@ -29,6 +29,7 @@ namespace okta_aspnet_webforms_example
                 PostLogoutRedirectUri = ConfigurationManager.AppSettings["okta:PostLogoutRedirectUri"],
                 GetClaimsFromUserInfoEndpoint = true,
                 Scope = new List<string> { "openid", "profile", "email" },
+                // AuthorizationServerId = null, // un-comment this line if you're not using a custom authorization server
             });
         }
     }


### PR DESCRIPTION
It took me a long time to figure out why an authorization endpoint of `/oauth2/${authServerId}/.well-known/openid-configuration` wasn't working for me, but `/.well-known/openid-configuration` was.  Adding this comment will help educate users about this option.