### PR TITLE
Fixed login page jQuery reference

### DIFF
--- a/self-hosted-login/okta-aspnet-webforms-example/Login.aspx
+++ b/self-hosted-login/okta-aspnet-webforms-example/Login.aspx
@@ -1,7 +1,7 @@
 ﻿<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="Login.aspx.cs" Inherits="okta_aspnet_webforms_example.Login" %>
 <script src="https://global.oktacdn.com/okta-signin-widget/5.2.0/js/okta-sign-in.min.js" type="text/javascript"></script>
 <link href="https://global.oktacdn.com/okta-signin-widget/5.2.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" />
-<script src="Scripts/jquery-3.4.1.min.js" type="text/javascript"></script>
+<script src="Scripts/jquery-3.6.0.min.js" type="text/javascript"></script>
 
 <div id="widget"></div>
 


### PR DESCRIPTION
The `Login.aspx` page was referencing jQuery `3.4.1` instead of `3.6.0`.