### PR TITLE
fix: resolved core-js and fsevents vulnerability by upgrading wait-on…

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -24,11 +24,16 @@
     "devDependencies": {
       "dotenv": "^5.0.1",
       "find-process": "^1.1.0",
-      "forever-monitor": "^1.7.1",
+      "forever-monitor": "^3.0.3",
       "jasmine-reporters": "^2.2.0",
       "platform": "^1.3.5",
       "protractor": "^5.1.0",
-      "wait-on": "^2.0.2"
+      "wait-on": "^8.0.1"
+    },
+    "overrides": {
+      "chokidar": {
+        "fsevents": "2.3.3"
+      }
     },
     "bin": {},
     "private": true


### PR DESCRIPTION
… and fsevents package


Upgraded wait-on from version 2.0.2 as the previous version was using core-is which was no longer maintained which helped to resolve the vulnerability.
Used override to upgrade the fsevents version as it was a dependency of forever-monitor->chokidar->fsevent because of which direct upgrade was not possible.